### PR TITLE
add test for defined LTC_MRSA to rand_prime.c

### DIFF
--- a/src/math/rand_prime.c
+++ b/src/math/rand_prime.c
@@ -10,7 +10,7 @@
  */
 #include "tomcrypt.h"
 
-#if !defined LTC_NO_MATH && !defined LTC_NO_PRNGS
+#if (!defined LTC_NO_MATH && !defined LTC_NO_PRNGS) || defined LTC_MRSA
 
 /**
   @file rand_prime.c


### PR DESCRIPTION
I further suggest adding this explanatory comment above it:
/\* if RSA is enabled, make_rsa is compiled, which depends on rand_prime */
